### PR TITLE
hotfix: merging of devices API on backend conflicts

### DIFF
--- a/raptgen/dev.py
+++ b/raptgen/dev.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import List, Dict, Set
 
-from routers import session, test, data, upload
+from routers import session, test, data, upload, training
 
 app = FastAPI()
 
@@ -25,7 +25,7 @@ app.include_router(session.router)
 app.include_router(data.router)
 app.include_router(test.router)
 app.include_router(upload.router)
-
+app.include_router(training.router)
 
 def print_spec() -> str:
     return str(app.openapi())

--- a/raptgen/routers/training.py
+++ b/raptgen/routers/training.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, File, Form
 router = APIRouter()
 
 
-@router.get("/train/device/process")
+@router.get("/api/train/device/process")
 async def get_available_devices():
     devices = ["CPU"]
 
@@ -12,4 +12,4 @@ async def get_available_devices():
         cuda_device_count = torch.cuda.device_count()
         devices.extend([f"CUDA:{i}" for i in range(cuda_device_count)])
 
-    return {"devices": devices}
+    return devices

--- a/visualizer/mock/route/train.ts
+++ b/visualizer/mock/route/train.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import * as trainZod from "../../services/api-client";
 
 export const mockURL = (path: string) => {
-  return `http://localhost:3000/api${path}`;
+  return `http://localhost:8000/api${path}`;
 };
 
 const uuids = {
@@ -57,12 +57,12 @@ export const trainHandlers = [
     return res(ctx.status(200), ctx.json({ message: "hello" }));
   }),
 
-  rest.get(mockURL("/train/device/process"), (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json(["cpu", "cuda:0", "cuda:1", "cuda:2", "cuda:3"])
-    );
-  }),
+  // rest.get(mockURL("/train/device/process"), (req, res, ctx) => {
+  //   return res(
+  //     ctx.status(200),
+  //     ctx.json(["cpu", "cuda:0", "cuda:1", "cuda:2", "cuda:3"])
+  //   );
+  // }),
 
   rest.post(mockURL("/train/jobs/submit"), async (req, res, ctx) => {
     if (trainZod.requestPostSubmitJob.safeParse(await req.json())) {


### PR DESCRIPTION
hi
いただいた device API の backend を front 側から試してもらったのですが、そのままだと上手くいかなかったのでいくつか調整を行いました。
ひとまず notion に記述したドキュメントの通り第一階層に string[] データを置いたのですが、確かに第二階層において、 `devices` と名前を付けた方が視認性は上がりそうですね…。
どうしましょうかね。今は保留にして将来書き換えましょうか