### PR TITLE
fix: added task.db to the git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -291,5 +291,7 @@ Temporary Items
 
 # ignore lock file of yarn
 **/yarn.lock
-# test db
+
+# ignore database file
 raptgen/data/test_tasks.db
+raptgen/data/tasks.db


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Chore: `.gitignore`ファイルに新たなエントリーを追加し、`raptgen/data/tasks.db`データベースファイルをGitのトラッキングから除外しました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->