### PR TITLE
Test/no ref/use semaphore

### DIFF
--- a/raptgen/core/jobs.py
+++ b/raptgen/core/jobs.py
@@ -27,9 +27,14 @@ from tasks import celery
 from threading import Semaphore
 
 # Use a semaphore to limit the number of concurrent jobs
-semaphore_dict = {
-    "CPU": Semaphore(value=2),
-} | {f"CUDA:{i}": Semaphore(value=2) for i in range(torch.cuda.device_count())}
+if torch.cuda.is_available():
+    semaphore_dict = {
+        "CPU": Semaphore(value=2),
+    } | {f"CUDA:{i}": Semaphore(value=2) for i in range(torch.cuda.device_count())}
+else:
+    semaphore_dict = {
+        "CPU": Semaphore(value=2),
+    }
 
 
 class ChildJobTask(AbortableTask):

--- a/raptgen/routers/training.py
+++ b/raptgen/routers/training.py
@@ -419,15 +419,6 @@ async def run_parent_job(
                 database_url=database_url,
             )
 
-        # manage_jobs_raptgen.apply_async(
-        #     kwargs={
-        #         "parent_uuid": parent_id,
-        #         "training_params": request_param.params_training.dict(),
-        #         "database_url": database_url,
-        #     },
-        #     task_id=parent_id,
-        # )
-
         return JobSubmissionResponse(uuid=parent_id)
 
     elif isinstance(request_param, RaptGenFreqModel):
@@ -489,7 +480,7 @@ async def update_parent_job(
             detail=[
                 {
                     "loc": ["path", "parent_uuid"],
-                    "msg": "Job not found",
+                    "msg": f"Job {parent_uuid} not found",
                     "type": "value_error",
                 }
             ],
@@ -559,7 +550,7 @@ async def suspend_parent_job(
             detail=[
                 {
                     "loc": ["body", "uuid"],
-                    "msg": "Job not found",
+                    "msg": f"Job {request.uuid} not found",
                     "type": "value_error",
                 }
             ],
@@ -618,7 +609,7 @@ async def resume_parent_job(
             detail=[
                 {
                     "loc": ["body", "uuid"],
-                    "msg": "Job not found",
+                    "msg": f"Job {request.uuid} not found",
                     "type": "value_error",
                 }
             ],
@@ -630,7 +621,7 @@ async def resume_parent_job(
             detail=[
                 {
                     "loc": ["body", "uuid"],
-                    "msg": "Job is not suspended",
+                    "msg": f"Job {request.uuid} is not suspended",
                     "type": "value_error",
                 }
             ],
@@ -681,7 +672,7 @@ async def delete_parent_job(
             detail=[
                 {
                     "loc": ["body", "uuid"],
-                    "msg": "Job not found",
+                    "msg": f"Job {parent_uuid} not found",
                     "type": "value_error",
                 }
             ],
@@ -698,11 +689,9 @@ async def delete_parent_job(
         session.query(TrainingLosses).filter(
             TrainingLosses.child_uuid == child_job.uuid
         ).delete()
-    session.commit()
 
     session.query(SequenceData).filter(SequenceData.parent_uuid == parent_uuid).delete()
     child_jobs.delete()
-    session.commit()
 
     session.delete(parent_job)
     session.commit()

--- a/raptgen/tests/unit/test_train.py
+++ b/raptgen/tests/unit/test_train.py
@@ -399,9 +399,6 @@ def test_enqueue_job(db_session, celery_worker):
     assert parent_job.status == "success"
 
 
-from time import sleep
-
-
 def test_suspend_job(db_session, celery_worker):
     response = client.post(
         "/api/train/jobs/submit",
@@ -488,18 +485,11 @@ def test_resume_job(db_session, celery_worker):
             db_session.refresh(child_job)
     assert parent_job.status == "progress"
 
-    print(f"parent_job.status: {parent_job.status}")
-    for child_job in child_jobs:
-        print(f"child_job.status: {child_job.status}")
-
     while parent_job.status in {"progress"}:
         db_session.refresh(parent_job)
         for child_job in child_jobs:
             db_session.refresh(child_job)
 
-    print(f"parent_job.status: {parent_job.status}")
-    for child_job in child_jobs:
-        print(f"child_job.status: {child_job.status}")
     for child_job in child_jobs:
         assert child_job.status == "success"
     assert parent_job.status == "success"


### PR DESCRIPTION
Celery の map を使用すると独自継承 Task が規定の Task class として認識されてしまい、celery.signal を利用するしか on_success, on_failure 等を実行することができない状態であることが分かりました。queue 等の他の workflow もありますが、これらは実行失敗時の動作を扱えないため今回のタスクには合わないことが分かりました。

この PR では semaphore を用いて 同時実行数を制限したまま複数タスクを実行することを試みました。Celery の機能を使って task の rate limit を変動させる手もありますが、これは単位時間当たりのジョブ実行回数を制限するものであり、今回は空間計算量を制限したいので不採用にしました。

https://zenn.dev/yosemat/articles/39c36d0ed88a7c

また、本 PR は以下の実装とテストを含んでいます。
* run_parent_job
* suspend_parent_job
* resume_parent_job
* delete_parent_job
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- New Feature: `training.py`にジョブの一時停止、再開、削除を行う新しいエンドポイントが追加されました。これにより、ジョブの管理と制御がより柔軟になります。
- Test: 新機能のテストケースが`test_train.py`に追加され、`eager_mode`パラメータと関連コメントが削除されました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->