### PR TITLE
feat: Fix child job minimum NLL calculation

### DIFF
--- a/raptgen/routers/training.py
+++ b/raptgen/routers/training.py
@@ -880,9 +880,7 @@ async def publish_parent_job(
         inplace=True,
     )
 
-    model_binary: bytes = (
-        session.query(ChildJob).filter(ChildJob.uuid == uuid).first().optimal_checkpoint
-    )  # type: ignore
+    model_binary: bytes = session.query(ChildJob).filter(ChildJob.uuid == uuid).first().optimal_checkpoint  # type: ignore
     state_dict_map = torch.load(BytesIO(model_binary))
     state_dict = state_dict_map["model"]
 


### PR DESCRIPTION
This PR fixes the calculation of the minimum negative log-likelihood (NLL) for child jobs in the `get_parent_job` function. Previously, the code was not properly checking for `None` values before calculating the minimum NLL. This commit adds a check to ensure that the minimum NLL is not `None` and not `NaN` before appending it to the summary.

Refactor the code in `get_parent_job` to handle the case where `child_job.minimum_NLL` is `None` and not `NaN`.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Bug fix: `get_parent_job`関数内で`child_job.minimum_NLL`が`None`または`NaN`でないことを確認するチェックを追加し、`minimum_NLL`の計算を修正しました。これにより、`summary["minimum_NLLs"]`に正しい値が追加されるようになりました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->