### PR TITLE
added PUT API test

### DIFF
--- a/raptgen/core/db.py
+++ b/raptgen/core/db.py
@@ -331,7 +331,9 @@ class RegisteredValues(BaseSchema):
     id = Column(
         Integer, primary_key=True, unique=True, autoincrement=True
     )  # ID for each registered value
-    experiment_uuid = Column(String, ForeignKey("experiments.uuid"))
+    experiment_uuid = Column(
+        String, ForeignKey("experiments.uuid", ondelete="CASCADE", onupdate="CASCADE")
+    )
     value_id = Column(String)  # Registered value ID
     sequence = Column(String)  # Sequence information
     target_values = relationship("TargetValues", backref="registered_values")
@@ -342,7 +344,9 @@ class TargetColumns(BaseSchema):
     id = Column(
         Integer, primary_key=True, unique=True, autoincrement=True
     )  # ID for each target column
-    experiment_uuid = Column(String, ForeignKey("experiments.uuid"))
+    experiment_uuid = Column(
+        String, ForeignKey("experiments.uuid", ondelete="CASCADE", onupdate="CASCADE")
+    )
     column_name = Column(String)  # Target column name
     target_values = relationship("TargetValues", backref="target_columns")
 
@@ -352,7 +356,9 @@ class TargetValues(BaseSchema):
     id = Column(
         Integer, primary_key=True, unique=True, autoincrement=True
     )  # ID for each target value
-    experiment_uuid = Column(String, ForeignKey("experiments.uuid"))
+    experiment_uuid = Column(
+        String, ForeignKey("experiments.uuid", ondelete="CASCADE", onupdate="CASCADE")
+    )
     registered_values_id = Column(Integer, ForeignKey("registered_values.id"))
     target_column_id = Column(Integer, ForeignKey("target_columns.id"))
     value = Column(Float)
@@ -363,7 +369,9 @@ class QueryData(BaseSchema):
     id = Column(
         Integer, primary_key=True, unique=True, autoincrement=True
     )  # ID for each query data entry
-    experiment_uuid = Column(String, ForeignKey("experiments.uuid"))
+    experiment_uuid = Column(
+        String, ForeignKey("experiments.uuid", ondelete="CASCADE", onupdate="CASCADE")
+    )
     sequence = Column(String)  # Sequence information
     coord_x_original = Column(Float)  # Original X coordinate
     coord_y_original = Column(Float)  # Original Y coordinate
@@ -374,7 +382,9 @@ class AcquisitionData(BaseSchema):
     id = Column(
         Integer, primary_key=True, unique=True, autoincrement=True
     )  # ID for each acquisition data entry
-    experiment_uuid = Column(String, ForeignKey("experiments.uuid"))
+    experiment_uuid = Column(
+        String, ForeignKey("experiments.uuid", ondelete="CASCADE", onupdate="CASCADE")
+    )
     coord_x = Column(Float)  # X coordinate
     coord_y = Column(Float)  # Y coordinate
     value = Column(Float)  # Value corresponding to the coordinates

--- a/raptgen/tests/unit/test_bo.py
+++ b/raptgen/tests/unit/test_bo.py
@@ -245,6 +245,136 @@ def test_get_items_failure(db_session):
     assert response.status_code == 404
 
 
+def test_put_items_success(db_session):
+    mock_db(db_session, BOTest.PUT_items_success)
+
+    # check the initial data
+
+    # check if the experiment was added to the database
+    experiment = (
+        db_session.query(Experiments)
+        .filter_by(uuid="00000000-0000-0000-0000-000000000000")
+        .first()
+    )
+
+    db_session.commit()
+
+    assert experiment is not None
+    assert experiment.name == "multiple_data"
+
+    response = client.put(
+        "/api/bayesopt/items/00000000-0000-0000-0000-000000000000",
+        json={
+            "experiment_name": "test_experiment_updated",
+            "VAE_model": "test_model_updated",
+            "plot_config": {
+                "minimum_count": 3,
+                "show_training_data": False,
+                "show_bo_contour": False,
+            },
+            "optimization_config": {
+                "method_name": "qEI",
+                "target_column_name": "target_updated",
+                "query_budget": 9,
+            },
+            "distribution_params": {
+                "xlim_start": 2,
+                "xlim_end": 3,
+                "ylim_start": 2,
+                "ylim_end": 3,
+            },
+            "registered_table": {
+                "ids": ["1"],
+                "sequences": ["GGG"],
+                "target_column_names": ["target_updated"],
+                "target_values": [[0.6]],
+            },
+            "query_table": {
+                "sequences": ["AAG"],
+                "coords_x_original": [2],
+                "coords_y_original": [3],
+            },
+            "acquisition_mesh": {
+                "coords_x": [4],
+                "coords_y": [5],
+                "values": [6],
+            },
+        },
+    )
+
+    assert response.status_code == 200
+
+    # check if the experiment was updated in the database
+    experiment = (
+        db_session.query(Experiments)
+        .filter_by(uuid="00000000-0000-0000-0000-000000000000")
+        .first()
+    )
+
+    db_session.commit()
+
+    assert experiment is not None
+    assert experiment.name == "test_experiment_updated"
+
+
+def test_put_items_failure_uuid_invalid(db_session):
+    mock_db(db_session, BOTest.PUT_items_failure_uuid_invalid)
+
+    response = client.put(
+        "/api/bayesopt/items/bad00000-0000-0000-0000-000000000000",
+        json={
+            "experiment_name": "bad_test_experiment_updated",
+            "VAE_model": "bad_test_model_updated",
+            "plot_config": {
+                "minimum_count": 3,
+                "show_training_data": False,
+                "show_bo_contour": False,
+            },
+            "optimization_config": {
+                "method_name": "qEI",
+                "target_column_name": "target_updated",
+                "query_budget": 9,
+            },
+            "distribution_params": {
+                "xlim_start": 2,
+                "xlim_end": 3,
+                "ylim_start": 2,
+                "ylim_end": 3,
+            },
+            "registered_table": {
+                "ids": ["1"],
+                "sequences": ["GGG"],
+                "target_column_names": ["target_updated"],
+                "target_values": [[0.6]],
+            },
+            "query_table": {
+                "sequences": ["AAG"],
+                "coords_x_original": [2],
+                "coords_y_original": [3],
+            },
+            "acquisition_mesh": {
+                "coords_x": [4],
+                "coords_y": [5],
+                "values": [6],
+            },
+        },
+    )
+
+    assert response.status_code == 404
+
+
+def test_put_items_failure_payload_invalid(db_session):
+    mock_db(db_session, BOTest.PUT_items_failure_payload_invalid)
+
+    response = client.put(
+        "/api/bayesopt/items/00000000-0000-0000-0000-000000000000",
+        json={
+            "experiment_name": "only_experiment_name",
+        },
+    )
+
+    assert response.status_code == 422
+
 
 def test_submit_bo_result(db_session):
     mock_db(db_session, BOTest.POST_submit_success)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
### リリースノート

- Refactor: データベースの外部キー制約に`ondelete="CASCADE"`および`onupdate="CASCADE"`を追加し、関連する行の自動削除を実現。
- Bug fix: `update_experiment_item`関数のエラーハンドリングを`ValueError`から`HTTPException`に変更し、ステータスコード404を返すように修正。
- Test: PUT APIのテストを追加。成功ケース、UUIDが無効な場合の失敗ケース、ペイロードが無効な場合の失敗ケースを含む。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->