### PR TITLE
added patch test

### DIFF
--- a/raptgen/routers/optimization.py
+++ b/raptgen/routers/optimization.py
@@ -574,12 +574,21 @@ async def patch_experiment_item(
 ):
     # only target="experiment_name" is supported
     if request["target"] == "experiment_name":
+        # type-check
+        if db.Experiments.name.type.python_type is not type(request["value"]):
+            raise HTTPException(
+                status_code=422,
+                detail=f"Type mismatch: {type(request['value'])} != {db.Experiments.name.type.python_type}",
+            )
+
         session.query(db.Experiments).filter(
             db.Experiments.uuid == experiment_uuid
         ).update({db.Experiments.name: request["value"]})
         session.commit()
     else:
-        raise ValueError(f"Unknown target: {request['target']}")
+        raise HTTPException(
+            status_code=422, detail=f"Unknown target: {request['target']}"
+        )
 
 
 @router.delete("/api/bayesopt/items/{experiment_uuid}")

--- a/raptgen/tests/unit/test_bo.py
+++ b/raptgen/tests/unit/test_bo.py
@@ -376,6 +376,83 @@ def test_put_items_failure_payload_invalid(db_session):
     assert response.status_code == 422
 
 
+def test_patch_items_success(db_session):
+    mock_db(db_session, BOTest.PATCH_items_success)
+
+    # check the initial data
+    experiment = (
+        db_session.query(Experiments)
+        .filter_by(uuid="00000000-0000-0000-0000-000000000000")
+        .first()
+    )
+    assert experiment is not None
+    assert experiment.name == "multiple_data"
+
+    response = client.patch(
+        "/api/bayesopt/items/00000000-0000-0000-0000-000000000000",
+        json={
+            "target": "experiment_name",
+            "value": "patched_experiment_name",
+        },
+    )
+
+    assert response.status_code == 200
+
+    # check if the experiment was updated in the database
+    experiment = (
+        db_session.query(Experiments)
+        .filter_by(uuid="00000000-0000-0000-0000-000000000000")
+        .first()
+    )
+    db_session.commit()
+    assert experiment is not None
+    assert experiment.name == "patched_experiment_name"
+
+
+def test_patch_items_failure_invalid_target(db_session):
+    mock_db(db_session, BOTest.PATCH_items_failure_invalid_target)
+    # check the initial data
+    experiment = (
+        db_session.query(Experiments)
+        .filter_by(uuid="00000000-0000-0000-0000-000000000000")
+        .first()
+    )
+    assert experiment is not None
+    assert experiment.name == "multiple_data"
+
+    response = client.patch(
+        "/api/bayesopt/items/00000000-0000-0000-0000-000000000000",
+        json={
+            "target": "invalid_target",
+            "value": "valid_value",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_patch_items_failure_invalid_value_type(db_session):
+    mock_db(db_session, BOTest.PATCH_items_failure_invalid_target)
+    # check the initial data
+    experiment = (
+        db_session.query(Experiments)
+        .filter_by(uuid="00000000-0000-0000-0000-000000000000")
+        .first()
+    )
+    assert experiment is not None
+    assert experiment.name == "multiple_data"
+
+    response = client.patch(
+        "/api/bayesopt/items/00000000-0000-0000-0000-000000000000",
+        json={
+            "target": "experiment_name",
+            "value": 123,
+        },
+    )
+
+    assert response.status_code == 422
+
+
 def test_submit_bo_result(db_session):
     mock_db(db_session, BOTest.POST_submit_success)
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
### リリースノート

- New Feature: `patch_experiment_item`関数に対する型チェックとエラーハンドリングを追加し、HTTP 422エラーを返すように改善しました。
- Test: PATCHリクエストに対するテストケースを追加しました。成功ケースと無効なターゲット、無効な値のタイプに対する失敗ケースを含む3つの新しいテスト関数が含まれています。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->