### PR TITLE
added delete API test

### DIFF
--- a/raptgen/routers/optimization.py
+++ b/raptgen/routers/optimization.py
@@ -596,7 +596,17 @@ async def delete_experiment_item(
     experiment_uuid: str,
     session: Session = Depends(get_db_session),
 ):
-    # delete Experiments
+    # check if the uuid exists
+    if (
+        session.query(db.Experiments)
+        .filter(db.Experiments.uuid == experiment_uuid)
+        .one_or_none()
+        is None
+    ):
+        raise HTTPException(
+            status_code=404, detail=f"Experiment with uuid {experiment_uuid} not found"
+        )
+
     # ondelete="CASCADE" is set in the database schema,
     # so the related rows in other tables will be deleted automatically
     session.query(db.Experiments).filter(

--- a/raptgen/tests/unit/test_bo.py
+++ b/raptgen/tests/unit/test_bo.py
@@ -453,6 +453,65 @@ def test_patch_items_failure_invalid_value_type(db_session):
     assert response.status_code == 422
 
 
+def test_delete_items_success(db_session):
+    mock_db(db_session, BOTest.DELETE_items_success)
+    # check the initial data
+    experiment = (
+        db_session.query(Experiments)
+        .filter_by(uuid="00000000-0000-0000-0000-000000000000")
+        .first()
+    )
+    assert experiment is not None
+    assert experiment.name == "multiple_data"
+
+    response = client.delete("/api/bayesopt/items/00000000-0000-0000-0000-000000000000")
+
+    assert response.status_code == 200
+
+    # check if the experiment was deleted from the database
+    experiment = (
+        db_session.query(Experiments)
+        .filter_by(uuid="00000000-0000-0000-0000-000000000000")
+        .first()
+    )
+    db_session.commit()
+    assert experiment is None
+
+    # check the other data is safe and not effected
+    experiment = (
+        db_session.query(Experiments)
+        .filter_by(uuid="00000000-0000-0000-0000-000000000001")
+        .first()
+    )
+
+    assert experiment is not None
+
+
+def test_delete_items_failure(db_session):
+    mock_db(db_session, BOTest.DELETE_items_failure)
+    # check the initial data
+    experiment = (
+        db_session.query(Experiments)
+        .filter_by(uuid="00000000-0000-0000-0000-000000000000")
+        .first()
+    )
+    assert experiment is not None
+    assert experiment.name == "multiple_data"
+
+    response = client.delete("/api/bayesopt/items/bad00000-0000-0000-0000-000000000000")
+
+    assert response.status_code == 404
+
+    # check if the experiment was deleted from the database
+    experiment = (
+        db_session.query(Experiments)
+        .filter_by(uuid="00000000-0000-0000-0000-000000000000")
+        .first()
+    )
+    db_session.commit()
+    assert experiment is not None
+
+
 def test_submit_bo_result(db_session):
     mock_db(db_session, BOTest.POST_submit_success)
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- New Feature: UUIDが存在しない場合に404エラーを返す削除APIのチェックを追加しました。
- Test: `/api/bayesopt/items/{uuid}` エンドポイントの削除APIの成功ケースと失敗ケースのユニットテストを追加しました。成功ケースでは指定されたUUIDのアイテムが削除されることを確認し、失敗ケースでは存在しないUUIDを指定した場合に404エラーが返されることを確認します。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->