### PR TITLE
feat: Add GMM router to API

### DIFF
--- a/raptgen/api.py
+++ b/raptgen/api.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from routers import session, test, data, upload, training, optimization
+from routers import session, test, data, upload, training, optimization, gmm
 
 app = FastAPI()
 
@@ -24,6 +24,7 @@ app.include_router(test.router)
 app.include_router(upload.router)
 app.include_router(training.router)
 app.include_router(optimization.router)
+app.include_router(gmm.router)
 
 
 def print_spec() -> str:

--- a/raptgen/routers/gmm.py
+++ b/raptgen/routers/gmm.py
@@ -1,0 +1,81 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+
+from core.db import (
+    get_db_session,
+)
+
+router = APIRouter()
+
+
+class SubmitGMMJobPayload(BaseModel):
+    pass
+
+
+@router.post("/api/gmm/jobs/submit")
+async def submit_gmm_job(
+    request: SubmitGMMJobPayload, db: Session = Depends(get_db_session)
+):
+    pass
+
+
+class SearchGMMJobsPayload(BaseModel):
+    pass
+
+
+@router.post("/api/gmm/jobs/search")
+async def search_gmm_jobs(
+    request: SearchGMMJobsPayload, db: Session = Depends(get_db_session)
+):
+    pass
+
+
+class GetGMMJobPayload(BaseModel):
+    pass
+
+
+@router.get("/api/gmm/jobs/items/{uuid}")
+async def get_gmm_job(
+    uuid: str, request: GetGMMJobPayload, db: Session = Depends(get_db_session)
+):
+    pass
+
+
+class UpdateGMMJobPayload(BaseModel):
+    pass
+
+
+@router.patch("/api/gmm/jobs/items/{uuid}")
+async def update_gmm_job(
+    uuid: str, request: UpdateGMMJobPayload, db: Session = Depends(get_db_session)
+):
+    pass
+
+
+@router.delete("/api/gmm/jobs/items/{uuid}")
+async def delete_gmm_job(uuid: str, db: Session = Depends(get_db_session)):
+    pass
+
+
+class SuspendGMMJobPayload(BaseModel):
+    pass
+
+
+@router.post("/api/gmm/jobs/suspend")
+async def suspend_gmm_job(
+    request: SuspendGMMJobPayload, db: Session = Depends(get_db_session)
+):
+    pass
+
+
+class ResumeGMMJobPayload(BaseModel):
+    pass
+
+
+@router.post("/api/gmm/jobs/resume")
+async def resume_gmm_job(
+    request: ResumeGMMJobPayload, db: Session = Depends(get_db_session)
+):
+    pass

--- a/raptgen/tests/unit/mocks/__init__.py
+++ b/raptgen/tests/unit/mocks/__init__.py
@@ -1,3 +1,22 @@
+__all__ = [
+    "mock_children",
+    "mock_parents",
+    "mock_params_preprocessing",
+    "mock_params_raptgen",
+    "mock_embeddings",
+    "mock_training_losses",
+    "mock_bo_db",
+    "BOTest",
+    "C",
+    "GMMTest",
+    "mock_gmm_db",
+    "mock_gmm_latent_df_data",
+    "GMM_C",
+    "DFData",
+    "SequenceEmbedding",
+    "LatentData",
+]
+
 from .test_train_mock_children import mock_children
 from .test_train_mock_parents import (
     mock_parents,
@@ -7,3 +26,12 @@ from .test_train_mock_parents import (
 from .test_train_mock_embeddings import mock_embeddings
 from .test_train_mock_training_losses import mock_training_losses
 from .test_bo_mock_data import mock_bo_db, BOTest, C
+from .test_gmm_mock_data import (
+    GMMTest,
+    mock_gmm_db,
+    mock_gmm_latent_df_data,
+    C as GMM_C,
+    DFData,
+    SequenceEmbedding,
+    LatentData,
+)

--- a/raptgen/tests/unit/mocks/test_gmm_mock_data.py
+++ b/raptgen/tests/unit/mocks/test_gmm_mock_data.py
@@ -1,0 +1,180 @@
+"""
+This module contains mock data for the tests of the GMMJob and Trial modules.
+"""
+
+from dataclasses import dataclass
+from typing import List
+from enum import Enum
+
+
+class C:  # as "Constants"
+    # GMMJob table
+    GMMJob = "GMMJob"
+    id = "id"
+    uuid = "uuid"
+    target_VAE_model = "target_VAE_model"
+    minimum_n_components = "minimum_n_components"
+    maximum_n_components = "maximum_n_components"
+    step_size = "step_size"
+    n_trials_per_component = "n_trials_per_component"
+    status = "status"
+    name = "name"
+    start = "start"
+    duration = "duration"
+    trials_total = "trials_total"
+    trials_current = "trials_current"
+    optimal_trial_id = "optimal_trial_id"
+    current_trial_id = "current_trial_id"
+
+    # Trial table
+    Trial = "Trial"
+    gmm_job_id = "gmm_job_id"
+    trials_total = "trials_total"
+    current_trial_id = "current_trial_id"
+    current_trial_id_per_component = "current_trial_id_per_component"
+    n_components = "n_components"
+    means = "means"
+    covariances = "covariances"
+    BIC = "BIC"
+
+    # SequenceEmbeddings DF
+    random_region = "random_region"
+    coord_x = "coord_x"
+    coord_y = "coord_y"
+    duplicates = "duplicates"
+
+
+class GMMTest(Enum):
+    DB_INSERT_SUCCESS = "DB_INSERT_SUCCESS"
+    DF_INSERT_SUCCESS = "DF_INSERT_SUCCESS"
+    DATA_INSERT_SUCCESS = "DATA_INSERT_SUCCESS"
+
+    POST_submit_success = "POST_submit_success"
+    POST_submit_failure = "POST_submit_failure"
+    POST_search_success = "POST_search_success"
+    POST_search_failure = "POST_search_failure"
+    GET_items_uuid_success = "GET_items_uuid_success"
+    GET_items_uuid_failure = "GET_items_uuid_failure"
+    PATCH_items_uuid_success = "PATCH_items_uuid_success"
+    PATCH_items_uuid_failure = "PATCH_items_uuid_failure"
+    DELETE_items_uuid_success = "DELETE_items_uuid_success"
+    DELETE_items_uuid_failure = "DELETE_items_uuid_failure"
+    POST_suspend_success = "POST_suspend_success"
+    POST_suspend_failure = "POST_suspend_failure"
+    POST_resume_success = "POST_resume_success"
+    POST_resume_failure = "POST_resume_failure"
+    POST_publish_success = "POST_publish_success"
+    POST_publish_failure = "POST_publish_failure"
+
+
+mock_gmm_db = [
+    {
+        "tests": {GMMTest.DB_INSERT_SUCCESS, GMMTest.DATA_INSERT_SUCCESS},
+        "data": {
+            C.GMMJob: [
+                {
+                    C.id: 1,
+                    C.uuid: "11111111-1111-1111-1111-111111111111",
+                    C.target_VAE_model: "VAE_model_1",
+                    C.minimum_n_components: 3,
+                    C.maximum_n_components: 5,
+                    C.step_size: 1,
+                    C.n_trials_per_component: 1,
+                    C.status: "progress",
+                    C.name: "GMM Job 1",
+                    C.start: 1609459200,  # 2021-01-01 00:00:00
+                    C.duration: 3600,
+                    C.trials_total: 3,
+                    C.trials_current: 2,
+                    C.optimal_trial_id: -1,
+                    C.current_trial_id: 2,
+                },
+            ],
+            C.Trial: [
+                {
+                    C.id: 1,
+                    C.gmm_job_id: "11111111-1111-1111-1111-111111111111",
+                    C.trials_total: 3,
+                    C.current_trial_id: 1,
+                    C.current_trial_id_per_component: 1,
+                    C.n_components: 3,
+                    C.means: [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]],
+                    C.covariances: [
+                        [[0.1, 0.0], [0.0, 0.1]],
+                        [[0.2, 0.0], [0.0, 0.2]],
+                        [[0.3, 0.0], [0.0, 0.3]],
+                    ],
+                    C.BIC: 123.45,
+                },
+                {
+                    C.id: 2,
+                    C.gmm_job_id: "11111111-1111-1111-1111-111111111111",
+                    C.trials_total: 3,
+                    C.current_trial_id: 2,
+                    C.current_trial_id_per_component: 1,
+                    C.n_components: 4,
+                    C.means: [[0.2, 0.3], [0.4, 0.5], [0.6, 0.7], [0.8, 0.9]],
+                    C.covariances: [
+                        [[0.2, 0.0], [0.0, 0.2]],
+                        [[0.3, 0.0], [0.0, 0.3]],
+                        [[0.4, 0.0], [0.0, 0.4]],
+                        [[0.5, 0.0], [0.0, 0.5]],
+                    ],
+                    C.BIC: 234.56,
+                },
+            ],
+        },
+    }
+]
+
+
+@dataclass
+class SequenceEmbedding:
+    random_region: str
+    coord_x: float
+    coord_y: float
+    duplicates: int
+
+
+@dataclass
+class DFData:
+    name: str
+    data: List[SequenceEmbedding]
+
+
+@dataclass
+class LatentData:
+    tests: set[GMMTest]
+    data: List[DFData]
+
+
+mock_gmm_latent_df_data = [
+    LatentData(
+        tests={GMMTest.DF_INSERT_SUCCESS, GMMTest.DATA_INSERT_SUCCESS},
+        data=[
+            DFData(
+                name="VAE_model_1",
+                data=[
+                    SequenceEmbedding(
+                        random_region="AAAA",
+                        coord_x=0.1,
+                        coord_y=0.2,
+                        duplicates=1,
+                    ),
+                    SequenceEmbedding(
+                        random_region="AAAC",
+                        coord_x=0.3,
+                        coord_y=0.4,
+                        duplicates=2,
+                    ),
+                    SequenceEmbedding(
+                        random_region="AACC",
+                        coord_x=0.5,
+                        coord_y=0.6,
+                        duplicates=3,
+                    ),
+                ],
+            ),
+        ],
+    ),
+]

--- a/raptgen/tests/unit/test_gmm.py
+++ b/raptgen/tests/unit/test_gmm.py
@@ -1,0 +1,229 @@
+from contextlib import contextmanager
+from pathlib import Path
+import pytest
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, scoped_session
+import pytest_postgresql.factories as factories
+from typing import List
+
+from fastapi import FastAPI, Request, status
+from fastapi.testclient import TestClient
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from mocks import (
+    mock_gmm_db,
+    mock_gmm_latent_df_data,
+    GMMTest,
+    GMM_C,
+    DFData,
+)
+from tasks import celery
+import pandas as pd
+
+from core.db import (
+    BaseSchema,
+    GMMJob,
+    Trial,
+    get_db_session,
+)
+
+from routers import gmm
+
+test_app = FastAPI()
+test_app.include_router(gmm.router)
+
+client = TestClient(test_app)
+
+
+def handler(request: Request, exc: Exception):
+    print(exc)
+    return JSONResponse(content={}, status_code=status.HTTP_422_UNPROCESSABLE_ENTITY)
+
+
+test_app.add_exception_handler(RequestValidationError, handler)
+
+
+def load_database(**kwargs):
+    connection = f"postgresql+psycopg2://{kwargs['user']}:@{kwargs['host']}:{kwargs['port']}/{kwargs['dbname']}"
+    engine = create_engine(connection)
+    BaseSchema.metadata.create_all(engine)
+    session = scoped_session(sessionmaker(bind=engine))
+
+    # commit the session
+    try:
+        session.commit()
+    except Exception as e:
+        session.rollback()
+        raise e
+    finally:
+        session.close()
+
+
+postgresql_proc = factories.postgresql_proc(load=[load_database])
+postgresql = factories.postgresql(
+    "postgresql_proc"
+)  # still need to check if this is actually needed or not
+
+
+@pytest.fixture(scope="session")
+def celery_config():
+    celery.conf.update(
+        broker_url="redis://localhost:6379/0",
+        result_backend="redis://localhost:6379/0",
+        task_serializer="json",
+        result_serializer="json",
+        accept_content=["pickle", "json"],
+        task_track_started=True,
+        result_persistent=True,
+    )
+    return {
+        "broker_url": "redis://localhost:6379/0",
+        "result_backend": "redis://localhost:6379/0",
+    }
+
+
+@pytest.fixture
+def eager_mode():
+    celery.conf.update(
+        task_always_eager=True,
+        task_eager_propagates=False,
+    )
+    yield None
+    celery.conf.update(
+        task_always_eager=False,
+        task_eager_propagates=False,
+    )
+
+
+@pytest.fixture
+def db_session(postgresql):
+    connection = f"postgresql+psycopg2://{postgresql.info.user}:@{postgresql.info.host}:{postgresql.info.port}/{postgresql.info.dbname}"
+    engine = create_engine(connection)
+    session = scoped_session(sessionmaker(bind=engine))
+
+    # override_dependencies of FastAPI app
+    test_app.dependency_overrides[get_db_session] = lambda: session
+
+    session.begin_nested()
+
+    yield session
+    # 'Base.metadata.drop_all(engine)' here specifically does not work. It is also not needed. If you leave out the session.close()
+    # all the tests still run, but you get a warning/error at the end of the tests.
+
+    session.rollback()
+    session.close()
+
+
+def mock_db(db_session, testcase: GMMTest):
+    """add mock data to the database"""
+    # DB data is written in the following format:
+
+    # get the data
+    data = [d for d in mock_gmm_db if testcase in d["tests"]][0]["data"]
+
+    # add the data to the database
+    for d in data[GMM_C.GMMJob]:
+        db_session.add(GMMJob(**d))
+    for d in data[GMM_C.Trial]:
+        db_session.add(Trial(**d))
+
+    db_session.commit()
+
+
+@contextmanager
+def mock_latent_df_data(testcase: GMMTest):
+    # create temp DB data
+
+    # get the data
+    l_dfdata: List[DFData] = [
+        datum
+        for latent_data in mock_gmm_latent_df_data
+        if testcase in latent_data.tests
+        for datum in latent_data.data
+    ]
+
+    from tempfile import TemporaryDirectory
+
+    with TemporaryDirectory() as temp_dir:
+        # the data will be read like this
+        # df = pd.read_pickle(
+        #     DATA_PATH + "items/" + VAE_model_name + "/unique_seq_dataframe.pkl"
+        # )
+        # df = df[["Sequence", "Duplicates", "Without_Adapters", "coord_x", "coord_y"]]
+
+        for df_data in l_dfdata:
+            # create pandas df and save to pickled file
+            df = pd.DataFrame(
+                columns=[
+                    "Sequence",
+                    "Without_Adapters",
+                    "coord_x",
+                    "coord_y",
+                    "Duplicates",
+                ],
+            )
+            for row in df_data.data:
+                new_row = pd.Series(
+                    [
+                        row.random_region,
+                        row.random_region,
+                        row.coord_x,
+                        row.coord_y,
+                        row.duplicates,
+                    ],
+                    index=df.columns,  # Ensure the Series has the same columns as the DataFrame
+                )
+
+                df = pd.concat([df, new_row.to_frame().T], ignore_index=True)
+
+            if not Path(temp_dir + f"/{df_data.name}").exists():
+                Path(temp_dir + f"/{df_data.name}").mkdir(parents=True, exist_ok=True)
+
+            df.to_pickle(
+                temp_dir + f"/{df_data.name}/unique_seq_dataframe.pkl",
+            )
+
+        yield temp_dir
+
+
+def test_mock_df(db_session):
+    with mock_latent_df_data(GMMTest.DATA_INSERT_SUCCESS) as mock_data_path:
+        assert mock_data_path is not None
+        assert Path(mock_data_path).exists()
+        assert Path(mock_data_path + "/VAE_model_1/unique_seq_dataframe.pkl").exists()
+        assert Path(mock_data_path + "/VAE_model_1/unique_seq_dataframe.pkl").is_file()
+        assert (
+            Path(mock_data_path + "/VAE_model_1/unique_seq_dataframe.pkl")
+            .stat()
+            .st_size
+            > 0
+        )
+
+        # read mock data
+        df = pd.read_pickle(mock_data_path + "/VAE_model_1/unique_seq_dataframe.pkl")
+        assert df is not None
+        assert isinstance(df, pd.DataFrame)
+        assert df.shape[0] == 3
+        assert df.shape[1] == 5
+        assert df.columns.tolist() == [
+            "Sequence",
+            "Without_Adapters",
+            "coord_x",
+            "coord_y",
+            "Duplicates",
+        ]
+
+
+def test_mock_db(db_session):
+    mock_db(db_session, GMMTest.DB_INSERT_SUCCESS)
+
+    # check if the data is in the database
+    assert db_session.query(GMMJob).count() == 1
+    assert db_session.query(GMMJob).first().start == 1609459200
+    assert db_session.query(Trial).count() == 2
+    assert db_session.query(Trial).first().trial_id == 1
+    assert db_session.query(Trial).first().n_components == 3
+    assert db_session.query(Trial).first().current_trial_id == 1
+    assert db_session.query(Trial).first().current_trial_id_per_component == 1
+    assert db_session.query(Trial).first().trials_total == 50


### PR DESCRIPTION
This commit adds a new router, `gmm.py`, to the API. The router includes endpoints for submitting, searching, getting, updating, and deleting GMM jobs. It also includes endpoints for suspending and resuming GMM jobs. The router is included in the main `api.py` file.

This fixed #97 