### PR TITLE
fix: could not parse fastq/fasta when an id has spaces

### DIFF
--- a/visualizer/components/common/parse-selex.tsx
+++ b/visualizer/components/common/parse-selex.tsx
@@ -22,9 +22,9 @@ const parseSelex = async (file: File) => {
   let regex;
   let match: RegExpExecArray | null;
   if (fileType === "fasta") {
-    regex = /^>\s*\S+[\n\r]+([ACGTUacgtu\n\r]+)$/gm;
+    regex = /^>[^\n\r]+[\n\r]+([ACGTUacgtu\n\r]+)$/gm;
   } else {
-    regex = /^@\s*\S+[\n\r]+([ACGTUacgtu\n\r]+)/gm;
+    regex = /^@[^\n\r]+[\n\r]+([ACGTUacgtu\n\r]+)$/gm;
   }
 
   let seqs: string[] = [];

--- a/visualizer/components/viewer/operator-control/encode/fasta-uploader.tsx
+++ b/visualizer/components/viewer/operator-control/encode/fasta-uploader.tsx
@@ -7,7 +7,7 @@ import { apiClient } from "~/services/api-client";
 import { setEncoded } from "../../redux/interaction-data";
 
 const parser = (text: string) => {
-  const regex = /^>\s*(\S+)[\n\r]+([ACGTUacgtu\n\r]+)$/gm;
+  const regex = /^>\s*([^\n\r]+)[\n\r]+([ACGTUacgtu\n\r]+)$/gm;
   let ids: string[] = [];
   let seqs: string[] = [];
   let match: RegExpExecArray | null;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Bug fix: FASTAおよびFASTQファイルのIDにスペースが含まれている場合に正しく解析できるように、正規表現を修正しました。これにより、ID部分の正規表現が`\S+`から`[^\n\r]+`に変更され、スペースを含むIDも正しく処理されるようになりました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->